### PR TITLE
bug fixed: creation of custom allocation when a member has multiple…

### DIFF
--- a/app/controllers/wl_custom_allocations_controller.rb
+++ b/app/controllers/wl_custom_allocations_controller.rb
@@ -6,6 +6,7 @@ class WlCustomAllocationsController < ApplicationController
   before_action :set_user
   before_action :authenticate
   before_action :retrieve_custom_alloc, except: [:new, :create]
+  before_action :retrieve_custom_project_window_list
 
   def new
   	@custom_allocation ||= WlCustomAllocation.new
@@ -62,6 +63,10 @@ class WlCustomAllocationsController < ApplicationController
 
   def retrieve_custom_alloc
     @custom_allocation ||= WlCustomAllocation.find(params[:id])
+  end
+
+  def retrieve_custom_project_window_list
+    @custom_project_window_list ||= WlCustomProjectWindow.where(user_id: @user.id, wl_project_window_id: @project.wl_project_window.id).order(:start_date).to_a
   end
 
 end

--- a/app/views/wl_custom_allocations/_form.html.erb
+++ b/app/views/wl_custom_allocations/_form.html.erb
@@ -28,3 +28,33 @@
 
 <% end %>
 </fieldset>
+
+<br />
+
+<fieldset>
+<legend>List of custom project windows for <%= user.name %> on this project</legend>
+	<% unless custom_project_window_list.empty? %> 
+		<div class="autoscroll">
+			<table class="list">
+				<thead>
+					<tr>
+						<th>Start date</th>
+						<th>End date</th>
+					</tr>
+				</thead>
+				<tbody>
+					<%- custom_project_window_list.each do |custom_project_window| %>
+						<tr>
+							<td><%= format_date(custom_project_window.start_date) %></td>
+							<td><%= format_date(custom_project_window.end_date) %></td>
+						</tr>
+					<%- end %>
+				</tbody>	
+			</table>
+		</div>
+	<% else %> 
+		<ul>No custom project window were found.</ul> 
+	<% end %> 
+
+
+</fieldset>

--- a/app/views/wl_custom_allocations/edit.html.erb
+++ b/app/views/wl_custom_allocations/edit.html.erb
@@ -1,2 +1,2 @@
 <h2>Edit the Custom Project Allocation for <%= @user.name %> (Project Window from <%= format_date(@project.wl_project_window.start_date) %> to <%= format_date(@project.wl_project_window.end_date) %>)</h2>
-<%= render 'form', :user => @user, :project => @project, :custom_allocation => @custom_allocation %>
+<%= render 'form', :user => @user, :project => @project, :custom_allocation => @custom_allocation, :custom_project_window_list => @custom_project_window_list %>

--- a/app/views/wl_custom_allocations/new.html.erb
+++ b/app/views/wl_custom_allocations/new.html.erb
@@ -1,2 +1,2 @@
 <h2>Add a Custom Project Allocation for <%= @user.name %> (Project Window from <%= format_date(@project.wl_project_window.start_date) %> to <%= format_date(@project.wl_project_window.end_date) %>)</h2>
-<%= render 'form', :user => @user, :project => @project, :custom_allocation => @custom_allocation %>
+<%= render 'form', :user => @user, :project => @project, :custom_allocation => @custom_allocation, :custom_project_window_list => @custom_project_window_list %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
   error_set: "An error occured. Please check that your parameters are correct"
   error_dates: "End date cannot take place before Start date"
   error_custom_alloc_boundary: "is outside project windows"
-  error_custom_alloc_boundary_c: "is outside custom project windows (%{from} - %{to})"
+  error_custom_alloc_boundary_c: "is outside of any custom project window period. Please check with the custom project window list"
   notice_custom_project_windows_set: "The custom project windows was correctly set for %{user} in %{project}"
   error_role_id_project_window_blanck: "Please select one or many roles"
+  error_not_valid_date: "Please check date entry"


### PR DESCRIPTION
… custom project windows

previous behavior:
if a member has multiple custom windows for one main project window (at least two) and the user tries to add a custom allocation on the second custom window ---> it was not working

Expected behavior:
if a member has multiple custom windows for one main project window (at least two). The user can add a custom allocation to any of the member's custom project window as the condition has been followed: the custom allocation dates should be included the custom project window period
