### PR TITLE
Fix creation multiple custom project windows

### DIFF
--- a/app/controllers/wl_custom_project_windows_controller.rb
+++ b/app/controllers/wl_custom_project_windows_controller.rb
@@ -39,9 +39,14 @@ class WlCustomProjectWindowsController < ApplicationController
 	end
 
 	def destroy
-		@custom_project_window.destroy
+		if @custom_project_window.destroy
+			flash[:notice] = l(:notice_custom_allocation_deleted, :user => @user.name)
+ 		else
+ 			flash[:error] = l(:error_delete_cpw)
+ 	   end
 		redirect_to :controller => 'wl_boards', :action => 'index'
 	end
+
 
 private
 

--- a/app/models/wl_custom_project_window.rb
+++ b/app/models/wl_custom_project_window.rb
@@ -26,19 +26,40 @@ private
 	def check_custom_allocations
 		custom_allocs = WlCustomAllocation.where(wl_project_window_id: self.wl_project_window.id, user_id: self.user.id)
 
-		custom_allocs.find_each do |c|
+		custom_windows = WlCustomProjectWindow.where(user_id: user_id, wl_project_window_id: wl_project_window_id)
 
-			if self.start_date > c.end_date || self.end_date < c.start_date
-				errors.add(:base, "Custom allocation \##{c.id} for #{c.user.name} from #{c.start_date} to #{c.end_date} needs to be moved first")
-			else
-				if self.start_date > c.start_date
-		  			c.update(start_date: self.start_date)
+		custom_allocs.find_each do |c_a|
+
+			c_a_valid = false
+			custom_windows.find_each do |c_w|
+				if c_w.start_date <= c_a.start_date && c_w.end_date >= c_a.end_date
+					c_a_valid = true
 				end
+				
+			end 
 
-				if self.end_date < c.end_date
-					c.update(end_date: self.end_date)
+			unless c_a_valid
+				unless self.start_date <= c_a.start_date && self.end_date >= c_a.end_date
+					errors.add(:base, "Custom allocation \##{c_a.id} for #{c_a.user.name} from #{c_a.start_date} to #{c_a.end_date} needs to be moved first")
 				end
 			end
+
+
+
+
+			#if self.start_date > c_a.end_date || self.end_date < c_a.start_date
+			#	errors.add(:base, "Custom allocation \##{c.id} for #{c.user.name} from #{c.start_date} to #{c.end_date} needs to be moved first")
+			#else
+			#	if self.start_date > c.start_date
+		  	#		c_a.update(start_date: self.start_date)
+			#	end
+#
+			#	if self.end_date < c.end_date
+			#		c_a.update(end_date: self.end_date)
+			#	end
+			#end
+
+
 		end
 	end
 

--- a/app/models/wl_custom_project_window.rb
+++ b/app/models/wl_custom_project_window.rb
@@ -12,12 +12,16 @@ class WlCustomProjectWindow < ActiveRecord::Base
   	validates :user_id, presence: true
   	before_update :check_custom_allocations
 	before_update :check_overtimes
+	before_destroy :check_existing_allocation
+	before_destroy :check_existing_overtime
 
 	validate :end_date_not_before_start_date
 	validate :dates_not_beyond_project_window
 	validate :check_custom_allocations
 	validate :check_overtimes
 	validate :custom_alloc_per_user_uniq_within_period
+	#validate :check_existing_allocation
+	#validate :check_existing_overtime
 
 	attr_accessible :start_date, :end_date, :wl_project_window_id, :user_id
 private
@@ -27,38 +31,24 @@ private
 		custom_allocs = WlCustomAllocation.where(wl_project_window_id: self.wl_project_window.id, user_id: self.user.id)
 
 		custom_windows = WlCustomProjectWindow.where(user_id: user_id, wl_project_window_id: wl_project_window_id)
+		custom_windows = custom_windows.where.not(id: self.id)
 
 		custom_allocs.find_each do |c_a|
 
 			c_a_valid = false
 			custom_windows.find_each do |c_w|
+				#if any custom allocation is in one of the existing custom project window period
 				if c_w.start_date <= c_a.start_date && c_w.end_date >= c_a.end_date
 					c_a_valid = true
 				end
-				
 			end 
 
-			unless c_a_valid
+			unless c_a_valid # if could not find a match between the custom allocation period and one of the existing custom project window period
+				# have a look with the current custom project window
 				unless self.start_date <= c_a.start_date && self.end_date >= c_a.end_date
 					errors.add(:base, "Custom allocation \##{c_a.id} for #{c_a.user.name} from #{c_a.start_date} to #{c_a.end_date} needs to be moved first")
 				end
 			end
-
-
-
-
-			#if self.start_date > c_a.end_date || self.end_date < c_a.start_date
-			#	errors.add(:base, "Custom allocation \##{c.id} for #{c.user.name} from #{c.start_date} to #{c.end_date} needs to be moved first")
-			#else
-			#	if self.start_date > c.start_date
-		  	#		c_a.update(start_date: self.start_date)
-			#	end
-#
-			#	if self.end_date < c.end_date
-			#		c_a.update(end_date: self.end_date)
-			#	end
-			#end
-
 
 		end
 	end
@@ -67,10 +57,36 @@ private
 		overtimes = WlUserOvertime.where(wl_project_window_id: self.wl_project_window.id, user_id: self.user.id)
 
 		overtimes.find_each do |c|
-			if self.start_date > c.start_date || self.end_date < c.end_date
+			#if overtime is out of the current custom project window period for the start date or end date
+			if self.start_date > c.start_date || self.end_date < c.end_date 
 				errors.add(:base, "Overtime \##{c.id} for #{c.user.name} from #{c.start_date} to #{c.end_date} needs to be moved first")
 			end
 		end
+	end
+
+	def check_existing_allocation
+		#if there is any custom allocation on the period of the current project window,
+		# we need to remove first the custom allocation before removing the current project window
+		custom_allocs = WlCustomAllocation.where(wl_project_window_id: self.wl_project_window.id, user_id: self.user.id)
+
+		custom_allocs.find_each do |c_a|
+			if c_a.start_date >= self.start_date && c_a.end_date <= self.end_date
+				return false
+			end
+		end
+	end
+
+	def check_existing_overtime
+		#if there is any overtime on the period of the current project window,
+		# we need to remove first the overtime before removing the current project window
+		overtimes = WlUserOvertime.where(wl_project_window_id: self.wl_project_window.id, user_id: self.user.id)
+
+		overtimes.find_each do |overtime|
+			if overtime.start_date >= self.start_date && overtime.end_date <= self.end_date
+				return false
+			end
+		end
+		
 	end
 
 end

--- a/app/views/wl_boards/_index.html.erb
+++ b/app/views/wl_boards/_index.html.erb
@@ -66,7 +66,7 @@
 				
 				<td><%= render_member_project_allocation(member, alloc[:start_date], alloc[:end_date]) %></td>
 				<td>
-					<div class="tooltip"><%= total_alloc[i][:percent_alloc] %>
+					<div class="tooltip"> <% if total_alloc[i][:percent_alloc] > 100 %> [!] <% end %> <%= total_alloc[i][:percent_alloc] %>
 		        		<span class="tip"><%= render_details_tooltip(alloc[:details], member)  %></span> 
 		  		    </div>
 				</td>
@@ -94,7 +94,6 @@
 					<span class="expander" onclick="toggleRowGroup(this);">&nbsp;</span>
       				Custom Project Windows 
        				<span class="count"><%= user_custom_pw.count %></span>
-        			<%= link_to_function("#{l(:button_collapse_all)}/#{l(:button_expand_all)}", "toggleAllRowGroups(this)", :class => 'toggle-all') %>
 				</td></tr>
 			<% end %>
 			<% user_custom_pw.each_with_index do |pw, i| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,17 +2,31 @@
 en:
   label_workload: "Allocation"
 
-  notice_project_windows_set: "The project windows was correctly set for %{project}"
+  #Project Window
+  notice_project_windows_set: "The project window was correctly set for %{project}"
+  error_project_windows_not_set: "Error: You must define a project window before continuing"
+  error_custom_alloc_boundary: "is outside project window"
+
+  #Custom Project Window
+  notice_custom_window_deleted: "The custom project window was successfully deleted for %{user}"
+  notice_custom_project_windows_set: "The custom project window was correctly set for %{user} in %{project}"
+  error_delete_cpw: "Can not delete the custom project window. Please check if there is any related custom project allocation or overtime"
+  error_custom_alloc_boundary_c: "is outside of any custom project window period. Please check with the custom project window list"
+
+  #Project Allocation
+  notice_project_allocation_set: "The default project allocation was correctly set for %{project}"
+  
+  #Custom Allocation
   notice_custom_allocation_set: "The custom allocation was correctly set for %{user}"
   notice_custom_allocation_deleted: "The custom allocation was successfully deleted for %{user}"
+  
+  #Overtime
   notice_user_overtime_set: "The overtime was correctly set for %{user}"
   notice_user_overtime_deleted: "The overtime was successfully deleted for %{user}"
-  notice_project_allocation_set: "The default project allocation was correctly set for %{project}"
-  error_project_windows_not_set: "Error: You must define a project window before continuing"
+  
+  #Common
   error_set: "An error occured. Please check that your parameters are correct"
   error_dates: "End date cannot take place before Start date"
-  error_custom_alloc_boundary: "is outside project windows"
-  error_custom_alloc_boundary_c: "is outside of any custom project window period. Please check with the custom project window list"
-  notice_custom_project_windows_set: "The custom project windows was correctly set for %{user} in %{project}"
   error_role_id_project_window_blanck: "Please select one or many roles"
   error_not_valid_date: "Please check date entry"
+  


### PR DESCRIPTION
```
- Fix Bug : (before)can not create a second custom project window if there was already one created with a custom project allocation (now) you can update existing custom project window, it will check if all the custom project allocation with still be consistent, you can create as much of custom project window as long as there is no overlapping 
- add [!] if the total allocation % is above 100%
- Complete: Check overtime & custom project allcoation before deleting a custom project window
```
