### PR TITLE
- add the total of project members on the allocation dashboard footer

### DIFF
--- a/app/helpers/wl_boards_helper.rb
+++ b/app/helpers/wl_boards_helper.rb
@@ -121,18 +121,18 @@ module WlBoardsHelper
   	def averageProjectAllocation(wl_members)
   	 	count_member_with_alloc  = 0
   	 	sum_members_average_project_alloc = 0
-  	 	sum_members_average_total_alloc = 0
+  	 	#sum_members_average_total_alloc = 0
   	 	wl_members.each do |member|
 
 			member_average_project_alloc = 0  	 		
-  	 		member_average_total_alloc = 0
+  	 		#member_average_total_alloc = 0
 
   	 		if member.wl_project_allocation?
   	 			count_member_with_alloc = count_member_with_alloc+1
   	 			total_alloc = member.wl_global_table_allocation
 					
 					sum_project_alloc = 0
-  	 				sum_total_alloc = 0
+  	 				#sum_total_alloc = 0
   	 				
   	 			total_alloc.each_with_index do |alloc, i|
   	 				working_days = member.user.working_days_count(alloc[:start_date], alloc[:end_date])
@@ -140,20 +140,21 @@ module WlBoardsHelper
   	 				p_allocation = member.wl_project_allocation_between(alloc[:start_date], alloc[:end_date])
   	 				sum_project_alloc += p_allocation*working_days
 
-					total_allocation = alloc[:percent_alloc]
-  	 				sum_total_alloc += total_allocation*working_days
+					#total_allocation = alloc[:percent_alloc]
+  	 				#sum_total_alloc += total_allocation*working_days
   	 			end
   	 			
   	 			window = WlProjectWindow.find_by(project_id: member.project_id)
   	 			window_working_days = member.user.working_days_count(window.start_date, window.end_date)
 
 				member_average_project_alloc = sum_project_alloc/window_working_days
-  	 			member_average_total_alloc = sum_total_alloc/window_working_days
+  	 			#member_average_total_alloc = sum_total_alloc/window_working_days
   	 		end
   	 		sum_members_average_project_alloc += member_average_project_alloc
-  	 		sum_members_average_total_alloc += member_average_total_alloc
+  	 		#sum_members_average_total_alloc += member_average_total_alloc
   	 	end
-  	 	result = {:average_pa => sum_members_average_project_alloc/count_member_with_alloc, :average_ta => sum_members_average_total_alloc/count_member_with_alloc}
+  	 	#result = {:total_alloc_members => count_member_with_alloc, :average_pa => sum_members_average_project_alloc/count_member_with_alloc, :average_ta => sum_members_average_total_alloc/count_member_with_alloc}
+  	 	result = {:total_alloc_members => count_member_with_alloc, :average_pa => sum_members_average_project_alloc/count_member_with_alloc}
   	 	return result
   	end
 

--- a/app/views/wl_boards/_index.html.erb
+++ b/app/views/wl_boards/_index.html.erb
@@ -148,6 +148,6 @@
 
 	</tbody>
 	<tfoot>
-		<tr style="font-weight: bold;"><td>Average</td><td><span class= "tog"></span></td><td colspan="4" ></td><td><%= averageProjectAllocation(wl_members)[:average_pa] %></td><td><%= averageProjectAllocation(wl_members)[:average_ta] %></td><td></td></tr>
+		<tr style="font-weight: bold;"><td title="Total of project members">Total: <%= averageProjectAllocation(wl_members)[:total_alloc_members] %></td><td><span class= "tog"></span></td><td colspan="4" ></td><td title="Average project allocation (%)">Average: <%= averageProjectAllocation(wl_members)[:average_pa] %></td><td></td><td></td></tr>
   	</tfoot>
 </table>


### PR DESCRIPTION
- remove the average total allocation on the allocation dashboard footer
