### PR TITLE
add tabs to the allocation plugin with dashboard, configure and check

### DIFF
--- a/app/controllers/wl_custom_allocations_controller.rb
+++ b/app/controllers/wl_custom_allocations_controller.rb
@@ -18,7 +18,7 @@ class WlCustomAllocationsController < ApplicationController
     @custom_allocation.wl_project_window_id = @project.wl_project_window.id
   	if @custom_allocation.save
       flash[:notice] = l(:notice_custom_allocation_set, :user => @user.name)
-      redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id
+      redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id, :tab => "wlconfigure"
     else
       flash[:error] = l(:error_set)
       render :new
@@ -31,7 +31,7 @@ class WlCustomAllocationsController < ApplicationController
   def update
   	if @custom_allocation.update(wl_custom_allocation_params)
       flash[:notice] = l(:notice_custom_allocation_set, :user => @user.name)
-      redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id
+      redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id, :tab => "wlconfigure"
     else
       flash[:error] = l(:error_set)
       render :edit
@@ -44,7 +44,7 @@ class WlCustomAllocationsController < ApplicationController
     else
       flash[:error] = l(:error_set)
     end
-    redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id
+    redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id, :tab => "wlconfigure"
   end
 
   private

--- a/app/controllers/wl_custom_project_windows_controller.rb
+++ b/app/controllers/wl_custom_project_windows_controller.rb
@@ -18,7 +18,7 @@ class WlCustomProjectWindowsController < ApplicationController
 		@custom_project_window.wl_project_window_id = @wl_project_window.id
 		if @custom_project_window.save
 			flash[:notice] = l(:notice_custom_project_windows_set, :project => @project.name, :user => @user.name)
-			redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id
+			redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id, :tab => "wlconfigure"
 		else
 			flash[:error] = l(:error_set)
 			render :new
@@ -31,7 +31,7 @@ class WlCustomProjectWindowsController < ApplicationController
 	def update
 		if @custom_project_window.update(wl_custom_project_window_params)
 			flash[:notice] = l(:notice_custom_project_windows_set, :project => @project.name, :user => @user.name)
-			redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id
+			redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id, :tab => "wlconfigure"
 		else
 			flash[:error] = l(:error_set)
 			render :new
@@ -44,7 +44,7 @@ class WlCustomProjectWindowsController < ApplicationController
  		else
  			flash[:error] = l(:error_delete_cpw)
  	   end
-		redirect_to :controller => 'wl_boards', :action => 'index'
+		redirect_to :controller => 'wl_boards', :action => 'index', :tab => "wlconfigure"
 	end
 
 

--- a/app/controllers/wl_project_allocations_controller.rb
+++ b/app/controllers/wl_project_allocations_controller.rb
@@ -21,7 +21,7 @@ class WlProjectAllocationsController < ApplicationController
 
     if @project_allocation.save
       flash[:notice] = l(:notice_project_allocation_set, :project => @project.name)
-      redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id
+      redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id, :tab => "wlconfigure"
     else
       flash[:error] = l(:error_set)
       render :new
@@ -34,7 +34,7 @@ class WlProjectAllocationsController < ApplicationController
   def update
     if @project_allocation.update(wl_project_allocation_params)
       flash[:notice] = l(:notice_project_allocation_set, :project => @project.name)
-      redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id
+      redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id, :tab => "wlconfigure"
     else
       flash[:error] = l(:error_set)
       render :edit

--- a/app/controllers/wl_project_windows_controller.rb
+++ b/app/controllers/wl_project_windows_controller.rb
@@ -21,7 +21,7 @@ class WlProjectWindowsController < ApplicationController
     if @project_window.save
   		flash[:notice] = l(:notice_project_windows_set, :project => @project.name)
   		#redirect_to :controller => 'projects', :action => 'settings', :id => @project.id, :tab => 'workload'
-      redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id
+      redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id, :tab => "wlconfigure"
   	else
   		flash[:error] = l(:error_set)
   		render :new
@@ -35,7 +35,7 @@ class WlProjectWindowsController < ApplicationController
   	if @project_window.update(wl_project_window_params)
   		flash[:notice] = l(:notice_project_windows_set, :project => @project.name)
   		#redirect_to :controller => 'projects', :action => 'settings', :id => @project.id, :tab => 'workload'
-      redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id
+      redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id, :tab => "wlconfigure"
   	else
   		flash[:error] = l(:error_set)
   		render :edit

--- a/app/controllers/wl_user_overtimes_controller.rb
+++ b/app/controllers/wl_user_overtimes_controller.rb
@@ -18,7 +18,7 @@ class WlUserOvertimesController < ApplicationController
     @user_overtime.wl_project_window_id = @project.wl_project_window.id
   	if @user_overtime.save
       flash[:notice] = l(:notice_user_overtime_set, :user => @user.name)
-      redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id
+      redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id, :tab => "wlconfigure"
     else
       flash[:error] = l(:error_set)
       render :new
@@ -31,7 +31,7 @@ class WlUserOvertimesController < ApplicationController
   def update
   	if @user_overtime.update(wl_user_overtime_params)
       flash[:notice] = l(:notice_user_overtime_set, :user => @user.name)
-      redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id
+      redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id, :tab => "wlconfigure"
     else
       flash[:error] = l(:error_set)
       render :edit
@@ -44,7 +44,7 @@ class WlUserOvertimesController < ApplicationController
     else
       flash[:error] = l(:error_set)
     end
-    redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id
+    redirect_to :controller => 'wl_boards', :action => 'index', :id => @project.id, :tab => "wlconfigure"
   end
 
   private

--- a/app/views/wl_boards/_check_index.html.erb
+++ b/app/views/wl_boards/_check_index.html.erb
@@ -1,0 +1,1 @@
+<p> Check project allocation with the logged time</p>

--- a/app/views/wl_boards/_configure_index.html.erb
+++ b/app/views/wl_boards/_configure_index.html.erb
@@ -1,0 +1,5 @@
+<h2>Configure the Allocation Dashboard from <%= format_date(@project.wl_project_window.start_date) %> to <%= format_date(@project.wl_project_window.end_date) %> (<%= link_to 'Edit', edit_project_wl_project_window_path(@project) %>)</h2>
+
+<p><strong>Note:</strong> <strong>"*"</strong> symbol in a Project Allocation column means a user has one or several overtimes during the time period considered.</p>
+
+<%= render 'configure_table', :project => @project, :wl_members => @wl_members %>

--- a/app/views/wl_boards/_configure_table.html.erb
+++ b/app/views/wl_boards/_configure_table.html.erb
@@ -31,11 +31,18 @@
 	</thead>
 	<tbody>
 
+		<!-- To calculate the average project allocation in the footer -->
+		<% pw_sum_alloc = 0 %>
+		<!-- _________________________________________________________ -->
+
+
 	<% wl_members.each do |member| %>
 		<% if member.wl_project_allocation? %>
 			<% total_alloc = member.wl_global_table_allocation %>
 			<% remaining_alloc = member.wl_remaining_table_allocation %>
 			<% project_alloc = member.wl_table_allocation %>
+
+			
 
 			<tr class="<%= cycle("odd", "even") %>" style="font-weight: bold; ">
 				<td><%= link_to member.user.name, User.find(member.user.id)  %>
@@ -56,10 +63,19 @@
 				</td>
 			</tr>
 
+			<!-- To calculate the average project allocation in the footer -->
+			<% member_sum_alloc = 0 %>
+			<!-- _________________________________________________________ -->
+
 			<% total_alloc.each_with_index do |alloc, i| %>
+
+				<!-- To calculate the average project allocation in the footer -->
+ 				<% member_sum_alloc += member.wl_sum_alloc_on_working_days(alloc[:start_date], alloc[:end_date]) %>
+				<!-- _________________________________________________________ -->
+
 				<% custom_alloc = WlCustomAllocation.where(user_id: member.user_id, wl_project_window_id: project.wl_project_window.id).overlaps(alloc[:start_date], alloc[:end_date]) %>
 
-				<tr class="<%= cycle("odd", "even") %> <%= "priority-highest" if (total_alloc[i][:percent_alloc] > 100) %> <%= "allocation-below" if (total_alloc[i][:percent_alloc] < 100) %>">
+				<tr class="<%= cycle("odd", "even") %> <%= "priority-highest" if (alloc[:percent_alloc] > 100) %> <%= "allocation-below" if (alloc[:percent_alloc] < 100) %>">
 				<td></td><td></td><td></td>
 				<td>
 					<% if custom_alloc.empty? %>
@@ -73,14 +89,14 @@
 				
 				<td><%= render_member_project_allocation(member, alloc[:start_date], alloc[:end_date]) %></td>
 				<td>
-					<div class="tooltip"> <% if total_alloc[i][:percent_alloc] > 100 %> [!] <% end %> <%= total_alloc[i][:percent_alloc] %>%
+					<div class="tooltip"> <% if alloc[:percent_alloc] > 100 %> [!] <% end %> <%= alloc[:percent_alloc] %>%
 		        		<span class="tip"><%= render_details_tooltip(alloc[:details], member)  %></span> 
 		  		    </div>
 				</td>
 				<td>
 					<% if custom_alloc.empty? %>
 						<% custom_link = { :start_date => alloc[:start_date], :end_date => alloc[:end_date], :percent_alloc => remaining_alloc[i][:percent_alloc]} %>
-						<% if total_alloc[i][:percent_alloc] > 100 %>
+						<% if alloc[:percent_alloc] > 100 %>
 							<div class="tooltip">
 								<%= link_to 'Smart Allocation', project_user_wl_custom_allocations_path(project, member.user,:wl_custom_allocation => custom_link), :class => 'icon icon-summary', :method => :post %>
 		        				<span class="tip"><%= render_smart_allocation_tooltip(custom_link) %></span>
@@ -95,6 +111,12 @@
 					<% end %></td>
 				</tr>
 			<% end %>
+
+			<!-- To calculate the average project allocation in the footer -->
+ 			<% pw_working_days = member.user.working_days_count(project.wl_project_window.start_date, project.wl_project_window.end_date) %>
+ 			<% pw_sum_alloc += member_sum_alloc/pw_working_days %>
+			<!-- _________________________________________________________ -->
+
 			<% user_custom_pw = WlCustomProjectWindow.where(user_id: member.user_id, wl_project_window_id: project.wl_project_window.id).order(:start_date) %>
 			<% if user_custom_pw.count > 0 %>
 				<tr class="group open"><td colspan="9">
@@ -148,6 +170,6 @@
 
 	</tbody>
 	<tfoot>
-		<tr style="font-weight: bold;"><td title="Total of project members">Total: <%= averageProjectAllocation(wl_members)[:total_alloc_members] %> members</td><td><span class= "tog"></span></td><td colspan="4" ></td><td title="Average project allocation (%)">Average project allocation: <%= averageProjectAllocation(wl_members)[:average_pa] %>%</td><td></td><td></td></tr>
+		<tr style="font-weight: bold;"><td title="Total of project members">Total: <%= total_members = wl_members.count %> members</td><td><span class= "tog"></span></td><td colspan="4" ></td><td title="Average project allocation (%)">Average project allocation: <%= pw_sum_alloc/total_members %>% </td><td></td><td></td></tr>
   	</tfoot>
 </table>

--- a/app/views/wl_boards/_dashboard_index.html.erb
+++ b/app/views/wl_boards/_dashboard_index.html.erb
@@ -1,0 +1,3 @@
+<h2>Allocation Dashboard from <%= format_date(@project.wl_project_window.start_date) %> to <%= format_date(@project.wl_project_window.end_date) %> </h2>
+
+<%= render 'dashboard_table', :project => @project, :wl_members => @wl_members %>

--- a/app/views/wl_boards/_dashboard_table.html.erb
+++ b/app/views/wl_boards/_dashboard_table.html.erb
@@ -1,0 +1,91 @@
+<table class="list">
+	<thead>
+		<tr>
+			<th>Project Member</th>
+			<th>Region</th>
+			<th>Role</th>
+			<th>Start Date</th>
+			<th>End Date</th>
+			<th>Project Allocation</th>
+			<th>Total Allocation</th>
+			<th>Overtime</th>
+		</tr>
+	</thead>
+	<tbody>
+		<% sum_all_members_palloc = 0 %>
+
+		<% wl_members.each do |member| %>
+			<tr style="background-color: #FFF1D3; font-weight: bold; ">
+				<td><%= link_to member.user.name, User.find(member.user.id) %></td>
+				<td><%= member.user.leave_preferences.region %></td>
+				<td><%= member.roles.map{ |role| role.name }.sort.join(", ") %></td>
+				<td colspan="5"></td>
+			</tr>
+			<% if member.wl_project_allocation? %>
+
+				
+				<% member_sum_project_alloc = 0 %>
+				<% member_sum_total_alloc = 0 %>
+
+				<% total_alloc = member.wl_global_table_allocation %>
+				<% total_alloc.each_with_index do |alloc, i| %>
+				
+							<% start_date = alloc[:start_date] %>
+							<% end_date = alloc[:end_date] %>
+
+				
+	 				<% member_sum_project_alloc += member.wl_sum_alloc_on_working_days(start_date, end_date) %>
+					<% member_sum_total_alloc +=  alloc[:percent_alloc]* member.user.working_days_count(start_date, end_date)%>
+
+					<% user_overtimes = WlUserOvertime.where(user_id: member.user_id, wl_project_window_id: member.project.wl_project_window.id).overlaps(alloc[:start_date], alloc[:end_date]).order(:start_date) %>
+					<% unless user_overtimes.empty? %>
+						<% user_overtimes.each_with_index do |overtime, index| %>
+							<% unless overtime.start_date == alloc[:start_date] %>
+								<% end_date = overtime.start_date-1 %>							
+								
+								<%= dashboard_row(member, start_date, end_date, alloc[:percent_alloc], alloc[:details]) %>
+ 								
+								<% start_date = overtime.start_date %>
+								<% end_date = overtime.end_date %>
+
+								<%= dashboard_row(member, start_date, end_date, alloc[:percent_alloc], alloc[:details], overtime) %>
+								
+								<% start_date = overtime.end_date+1 %>
+							<% else %>
+								<% end_date = overtime.end_date %>
+								
+								<%= dashboard_row(member, start_date, end_date, alloc[:percent_alloc], alloc[:details], overtime) %>
+
+								<% start_date = overtime.end_date+1 %>
+							<% end %>
+						<% end %>
+						<% unless  start_date > alloc[:end_date] %>
+								<% end_date = alloc[:end_date] %>
+								<%= dashboard_row(member, start_date, end_date, alloc[:percent_alloc], alloc[:details]) %>
+								<% start_date = alloc[:end_date]+1 %>
+						<% end %>
+					<% else %>
+						<%= dashboard_row(member, start_date, end_date, alloc[:percent_alloc], alloc[:details]) %>
+					<% end %>
+				<% end %>
+
+				
+	 			<% pw_working_days = member.user.working_days_count(project.wl_project_window.start_date, project.wl_project_window.end_date) %>
+	 			<% pw_sum_project_alloc = member_sum_project_alloc/pw_working_days %>
+	 			<% pw_sum_total_alloc = member_sum_total_alloc/pw_working_days %>
+				<% sum_all_members_palloc += pw_sum_project_alloc %>
+
+				<tr style="font-weight: bold;">
+					<td colspan="5"></td>
+					<td>Average project allocation: <%= pw_sum_project_alloc %>%</td>
+					<td>Average total allocation: <%= pw_sum_total_alloc %>%</td>
+					<td></td>
+				</tr>
+
+			<% end %>
+		<% end %>
+	</tbody>
+	<tfoot>
+		<tr style="background-color: #eeeeee; font-weight: bold;"><td title="Total of project members">Total: <%= total_members = wl_members.count %> members</td><td colspan="4" ></td><td title="Average project allocation (%)">Average project allocation: <%= sum_all_members_palloc/total_members %>% </td><td></td><td></td></tr>
+  	</tfoot>
+</table>

--- a/app/views/wl_boards/index.html.erb
+++ b/app/views/wl_boards/index.html.erb
@@ -1,11 +1,15 @@
- <%= javascript_include_tag 'index', :plugin => "redmine_workload_capacity" %>
+<h2>Allocation</h2>
+<script type="text/javascript">
+   wldashboardUrl = '<%=url_for(:controller => "wl_boards", :action => "index", :tab => "wldashboard")%>';
+   wlconfigureUrl = '<%=url_for(:controller => "wl_boards", :action => "index", :tab => "wlconfigure")%>'; 
+   wlcheckUrl = '<%=url_for(:controller => "wl_boards", :action => "index", :tab => "wlcheck")%>'; 
+</script>
 
-<h2>Allocation Dashboard from <%= format_date(@project.wl_project_window.start_date) %> to <%= format_date(@project.wl_project_window.end_date) %> (<%= link_to 'Edit', edit_project_wl_project_window_path(@project) %>)</h2>
+<%= render_tabs index_tabs %>
 
-<p><strong>Note:</strong> <strong>"*"</strong> symbol in a Project Allocation column means a user has one or several overtimes during the time period considered.</p>
-
-<%= render 'index', :project => @project, :wl_members => @wl_members %>
+<!-- <%= render 'dashboard_index', :project => @project, :wl_members => @wl_members %>-->
 
 <% content_for :header_tags do %>
     <%= stylesheet_link_tag 'workload_capacity', :plugin => 'redmine_workload_capacity' %>
+    <%= javascript_include_tag 'index', :plugin => "redmine_workload_capacity" %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,11 @@
 en:
   label_workload: "Allocation"
 
+  #Tabs
+  label_wldashboard: "Dashboard"
+  label_wlconfigure: "Configure"
+  label_wlcheck: "Check"
+
   #Project Window
   notice_project_windows_set: "The project window was correctly set for %{project}"
   error_project_windows_not_set: "Error: You must define a project window before continuing"

--- a/lib/redmine_workload_capacity/patches/member_patch.rb
+++ b/lib/redmine_workload_capacity/patches/member_patch.rb
@@ -51,6 +51,14 @@ module RedmineWorkloadCapacity
 				return 0
 			end
 
+			def wl_sum_alloc_on_working_days(from_date, to_date)
+	
+				working_days = self.user.working_days_count(from_date, to_date)
+  	 			p_allocation = self.wl_project_allocation_between(from_date, to_date)
+  	 			return p_allocation*working_days
+								
+			end
+
 			# Returns the total cross project allocation table, bound to current project window
 			def wl_global_table_allocation
 				user_table_alloc = self.user.wl_table_allocation

--- a/lib/redmine_workload_capacity/patches/user_patch.rb
+++ b/lib/redmine_workload_capacity/patches/user_patch.rb
@@ -43,21 +43,6 @@ module RedmineWorkloadCapacity
 				return WlUser.wl_manage_right?(self, project)
 			end
 
-			def working_days_count(from_date, to_date, include_sat = false, include_sun = false, include_bank_holidays = false)
-				user_region = LeavesHolidaysLogic.user_params(self, :region)
-				dates_interval = (from_date..to_date).to_a
-				
-				return dates_interval.count if include_sat && include_sun && include_bank_holidays
-
-    			dates_interval.delete_if {|i| i.wday == 6 && !include_sat || #delete date from array if day of week is a saturday (6)
-                			              i.wday == 0 && !include_sun || #delete date from array if day of week is a sunday (0)
-                            		      !include_bank_holidays && i.holiday?(user_region.to_sym, :observed)
-    									 }
-
-    			return dates_interval.count
-
-			end
-
 		end
 	end
 end

--- a/lib/redmine_workload_capacity/wl_users.rb
+++ b/lib/redmine_workload_capacity/wl_users.rb
@@ -29,15 +29,17 @@ module WlUser
 
 	def self.wl_members_for_project(project)
 		wl_members = []
-		wl_users = wl_users_for_project(project)
 		
-		unless wl_users.empty?
-			wl_users.each do |wl_user|
-				wl_members << Member.where(user_id: wl_user.id, project_id: project.id)
-				wl_members.flatten(1)
-			end
-			return wl_members.flatten
-		end
+		display_role_ids_list = WlProjectWindowLogic.retrieve_display_role_ids_list(project)
+		 unless display_role_ids_list.empty?
+		 	display_role_ids_list.each do |role_id|
+		 		role = Role.find(role_id)
+		 		wl_members << role.members.where(project_id: project.id)
+		 		wl_members.flatten
+		 	end
+		 	return wl_members.flatten.uniq.delete_if{|member| !member.user.active?}
+		 end
+		 
 	end
 
 	def self.wl_member?(member)


### PR DESCRIPTION
-dashboard is the allocation dashboard that sumarise the project window and all its characteristics.
-configure is the page to configure the allocation dashboard
-check will be the page to check the logged time of the project window's project members and its project allocation value
