### PR TITLE
2bug fixes:

### DIFF
--- a/app/models/wl_project_window.rb
+++ b/app/models/wl_project_window.rb
@@ -5,6 +5,9 @@ class WlProjectWindow < ActiveRecord::Base
   include WlLogic
 
   belongs_to :project
+
+  has_many :wl_user_overtime, :dependent => :destroy
+  
   has_many :wl_common_windows, :dependent => :destroy
   has_many :wl_overlaps, :through => :wl_common_windows
 
@@ -12,6 +15,7 @@ class WlProjectWindow < ActiveRecord::Base
   has_many :wl_custom_allocations, :dependent => :destroy
 
   has_many :wl_custom_project_windows, :dependent => :destroy
+
 
   before_update :check_custom_allocations
   before_update :check_overtimes

--- a/lib/redmine_workload_capacity/wl_users.rb
+++ b/lib/redmine_workload_capacity/wl_users.rb
@@ -29,15 +29,19 @@ module WlUser
 
 	def self.wl_members_for_project(project)
 		wl_members = []
-		
+		members = project.members.to_a
 		display_role_ids_list = WlProjectWindowLogic.retrieve_display_role_ids_list(project)
 		 unless display_role_ids_list.empty?
 		 	display_role_ids_list.each do |role_id|
 		 		role = Role.find(role_id)
-		 		wl_members << role.members.where(project_id: project.id)
-		 		wl_members.flatten
+		 		members.each do |member|
+					role_ids = member.roles.map{ |role| role.id }
+					if role.id.in?(role_ids)
+						wl_members << member
+					end
+				end	
 		 	end
-		 	return wl_members.flatten.uniq.delete_if{|member| !member.user.active?}
+		 	return wl_members.flatten.uniq
 		 end
 		 
 	end


### PR DESCRIPTION
- in WlUser.wl_members_for_project() a member can be a group as well
- in destroy entries on wl_user_overtime related to the wl_project_window when destroying wl_project_window
